### PR TITLE
Test/ 一般ユーザーの認証処理に関する機能テストの実装

### DIFF
--- a/src/tests/Feature/Http/Controllers/UserAuthControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/UserAuthControllerTest.php
@@ -35,4 +35,32 @@ class UserAuthControllerTest extends TestCase
         $response->assertRedirect('/');
         $response->assertSessionHas('success', 'ログインしました。');
     }
+
+    /**
+     * 異常系：
+     * 不正な値によって一般ユーザーの認証処理が失敗した場合のテスト
+     */
+    public function test_user_authenticate_with_invalid_input(): void
+    {
+        # 準備
+        $plain_password = 'test_password';
+        $user = User::factory()->create([
+            'password' => Hash::make($plain_password)
+        ]);
+        $invalid_password = 'invalid_password';
+        
+        # HTTPリクエスト
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            # 不正なパスワードを入力
+            'password' => $invalid_password
+        ]);
+
+        # アサーション
+        $this->assertGuest();
+        $response->assertRedirectBack();
+        $response->assertSessionHasErrors([
+            'login' => 'メールアドレスまたはパスワードが正しくありません。'
+        ]);
+    }
 }


### PR DESCRIPTION
## 概要
一般ユーザーの認証処理を行う`UserAuthController@authenticate`に対する機能テストを実装しました。

## テストの対象となるHTTPリクエスト
- `POST /login`

## テストの内容
### 一般ユーザーの認証において有効な値が入力された場合
- [x] ユーザーが一般ユーザーとしてログイン状態になっていること
- [x] `/`にリダイレクトしていること
- [x] `success`というセッションが保存されていること

### 一般ユーザーの認証において不正な値が入力された場合
- [x] ユーザーが認証されていない状態になっていること
- [x] 直前のページに戻っていること
- [x] セッションにエラー内容が含まれていること

## その他の変更点
- テストの実装において、「準備 -> 実行 -> 検証」を塊で認識できるようにコメントを追加しました。