### PR TITLE
Test/ 管理者ユーザーの認証機能の機能テストの実装

### DIFF
--- a/src/tests/Feature/Http/Controllers/AdminUserAuthControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/AdminUserAuthControllerTest.php
@@ -36,4 +36,30 @@ class AdminUserAuthControllerTest extends TestCase
         $this->assertAuthenticatedAs($admin_user, $guard);
         $response->assertSessionHas('success', '管理者としてログインしました。');
     }
+
+    /**
+     * 異常系：
+     * 不正な値の入力で管理者として認証に失敗する場合
+     */
+    public function test_admin_user_authentication_failed_with_invalid_input(): void
+    {
+        # 準備
+        $guard = 'admin';
+        $plain_password = 'test_password';
+        $admin_user = AdminUser::factory()->create([
+            'password' => Hash::make($plain_password)
+        ]);
+
+        # HTTPリクエスト
+        $response = $this->post('/admin/login', [
+            'email' => $admin_user->email,
+            'password' => 'wrong_pass'
+        ]);
+
+        # アサーション
+        $response->assertRedirectBackWithErrors([
+            'login' => 'ログインに失敗しました。'
+        ]);
+        $this->assertGuest();
+    }
 }


### PR DESCRIPTION
## 概要
管理者ユーザーの認証機能の機能テストの実装しました。

## 対象となるHTTPリクエスト
`POST /admin/login`

## テストの内容
### 認証に成功した場合
- `/admin/dashboard`にリダイレクトしていること
- 管理者として認証済みであること
- セッションに`key: 'success', value: '管理者としてログインしました。'`が存在していること

### 認証に失敗した場合
- 直前のページにリダイレクトしていること
- ユーザーが認証されていないこと
- セッションに`key: 'login', value: 'ログインに失敗しました。'`が存在していること